### PR TITLE
Avoid TypeError caused by deprecated widget under Plone 5.1

### DIFF
--- a/src/collective/disclaimer/config.py
+++ b/src/collective/disclaimer/config.py
@@ -1,2 +1,8 @@
 # -*- coding: utf-8 -*-
+from plone import api
+
+
 PROJECTNAME = 'collective.disclaimer'
+
+# BBB: remove on deprecation of Plone 4.3
+IS_BBB = api.env.plone_version().startswith('4.3')

--- a/src/collective/disclaimer/interfaces.py
+++ b/src/collective/disclaimer/interfaces.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.disclaimer import _
+from collective.disclaimer.config import IS_BBB
 from plone import api
-from plone.app.z3cform.wysiwyg import WysiwygFieldWidget
 from plone.autoform import directives as form
 from plone.supermodel import model
 from time import time
@@ -45,7 +45,12 @@ class IDisclaimerSettings(model.Schema):
     # XXX: we must use Text instead of RichText as we can only store
     #      primitive Python data types in plone.app.registry
     #      see: https://community.plone.org/t/1240
-    form.widget('text', WysiwygFieldWidget)
+    if IS_BBB:
+        # BBB: remove on deprecation of Plone 4.3
+        from plone.app.z3cform.wysiwyg import WysiwygFieldWidget
+        form.widget('text', WysiwygFieldWidget)
+    else:
+        form.widget('text', klass='pat-tinymce')
     text = schema.Text(
         title=_(u'title_text', default=u'Body text'),
         description=_(u'help_text', default=u'The text of the disclaimer.'),

--- a/src/collective/disclaimer/testing.py
+++ b/src/collective/disclaimer/testing.py
@@ -3,6 +3,7 @@
 
 For Plone 5 we need to install plone.app.contenttypes.
 """
+from collective.disclaimer.config import IS_BBB
 from plone import api
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE as PLONE_FIXTURE  # noqa: E501
 from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
@@ -10,10 +11,6 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
-
-
-IS_PLONE_5 = api.env.plone_version().startswith('5')
-IS_BBB = api.env.plone_version().startswith('4.3')
 
 
 class QIBBB:

--- a/src/collective/disclaimer/tests/test_setup.py
+++ b/src/collective/disclaimer/tests/test_setup.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 """Ensure add-on is properly installed and uninstalled."""
+from collective.disclaimer.config import IS_BBB
 from collective.disclaimer.config import PROJECTNAME
 from collective.disclaimer.interfaces import IBrowserLayer
 from collective.disclaimer.testing import INTEGRATION_TESTING
-from collective.disclaimer.testing import IS_BBB
 from collective.disclaimer.testing import QIBBB
 from plone.browserlayer.utils import registered_layers
 


### PR DESCRIPTION
Plone 5.1 no longer supports the use of the `plone.app.z3cform.wysiwyg.WysiwygFieldWidget` widget; replace it by the corresponding pattern.

See: https://community.plone.org/t/6478?u=hvelarde