### PR TITLE
ok cancel, move styles and scripts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
+- Add a ``disclaimer-inner`` wrapper to allow easier styling, e.g. positioning the viewlet centered on the website and darkening the whole background.
+  [thet]
+
 -  Move styles and scripts into the viewlet, so that they are included when using Diazo and just using the viewlet selector to copy the viewlet into the theme.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,8 @@ Changelog
 -  Move styles and scripts into the viewlet, so that they are included when using Diazo and just using the viewlet selector to copy the viewlet into the theme.
   [thet]
 
-- Add "OK" and "Cancel" buttons instead of the close link.
-  Both buttons close the viewlet but the storage key is only set when hitting OK.
+- Add an "OK" button instead of the close link.
+  When the button is hit, the viewlet is closed and the storage key is set.
   Previously the storage key was immediately set even without using the "close" link.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
+-  Move styles and scripts into the viewlet, so that they are included when using Diazo and just using the viewlet selector to copy the viewlet into the theme.
+  [thet]
+
 - Add "OK" and "Cancel" buttons instead of the close link.
   Both buttons close the viewlet but the storage key is only set when hitting OK.
   Previously the storage key was immediately set even without using the "close" link.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
+- Add "OK" and "Cancel" buttons instead of the close link.
+  Both buttons close the viewlet but the storage key is only set when hitting OK.
+  Previously the storage key was immediately set even without using the "close" link.
+  [thet]
+
 - Fix translation of default values on configlet (HT @fredvd).
   [hvelarde]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 1.0b1 (unreleased)
 ------------------
 
+- Register the controlpanel for any context.
+  The correct registry is automatically acquired.
+  This way, it's possible to set different disclaimer texts in a Lineage site with lineage.registry installed.
+  [thet]
+
 - Add a ``disclaimer-inner`` wrapper to allow easier styling, e.g. positioning the viewlet centered on the website and darkening the whole background.
   [thet]
 

--- a/src/collective/disclaimer/browser/configure.zcml
+++ b/src/collective/disclaimer/browser/configure.zcml
@@ -11,7 +11,7 @@
 
   <browser:page
       class=".controlpanel.DisclaimerSettingsControlPanel"
-      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      for="*"
       layer="collective.disclaimer.interfaces.IBrowserLayer"
       name="disclaimer-settings"
       permission="collective.disclaimer.Setup"

--- a/src/collective/disclaimer/browser/disclaimer.pt
+++ b/src/collective/disclaimer/browser/disclaimer.pt
@@ -16,22 +16,22 @@
   <script>
   if (Storage !== undefined) {
     $(document).ready(function () {
-      'use strict';
+      "use strict";
 
-      var enabled = $('#viewlet-disclaimer').attr('data-enabled');
-      if (enabled !== 'true') {
+      var enabled = $("#viewlet-disclaimer").attr("data-enabled");
+      if (enabled !== "true") {
         return;
       }
 
-      var last_modified = $('#viewlet-disclaimer').attr('data-last-modified');
-      var last_seen = localStorage.getItem('collective.disclaimer');
+      var last_modified = $("#viewlet-disclaimer").attr("data-last-modified");
+      var last_seen = localStorage.getItem("collective.disclaimer");
       if (last_seen === null || last_seen < last_modified) {
-        $('#viewlet-disclaimer').show();
+        $("#viewlet-disclaimer").show();
       }
 
-      $('button[name="collective.disclaimer.ok"]').click(function (event) {
+      $("button[name='collective.disclaimer.ok']").click(function (event) {
         event.preventDefault();
-        localStorage.setItem('collective.disclaimer', last_modified);
+        localStorage.setItem("collective.disclaimer", last_modified);
         $("#viewlet-disclaimer").hide();
       });
 

--- a/src/collective/disclaimer/browser/disclaimer.pt
+++ b/src/collective/disclaimer/browser/disclaimer.pt
@@ -1,15 +1,18 @@
 <div id="viewlet-disclaimer" role="alert" style="display: none"
     tal:attributes="data-enabled view/enabled;
                     data-last-modified view/last_modified">
-
   <link href="disclaimer.css" rel="stylesheet" tal:attributes="href string:${view/site_url}/++resource++collective.disclaimer/disclaimer.css">
 
-  <div class="disclaimer-title" tal:content="view/title">Title</div>
-  <div class="disclaimer-text" tal:content="structure view/text">
-    Disclaimer
+  <div class="disclaimer-inner">
+
+    <div class="disclaimer-title" tal:content="view/title">Title</div>
+    <div class="disclaimer-text" tal:content="structure view/text">
+      Disclaimer
+    </div>
+    <button name="collective.disclaimer.ok" i18n:translate="title_button_ok">OK</button>
+    <button name="collective.disclaimer.cancel" i18n:translate="title_button_cancel">Cancel</button>
+
   </div>
-  <button name="collective.disclaimer.ok" i18n:translate="title_button_ok">OK</button>
-  <button name="collective.disclaimer.cancel" i18n:translate="title_button_cancel">Cancel</button>
 
   <script>
   if (Storage !== undefined) {

--- a/src/collective/disclaimer/browser/disclaimer.pt
+++ b/src/collective/disclaimer/browser/disclaimer.pt
@@ -1,36 +1,43 @@
-<link href="disclaimer.css" rel="stylesheet"
-    tal:attributes="href string:${view/site_url}/++resource++collective.disclaimer/disclaimer.css">
+<link href="disclaimer.css" rel="stylesheet" tal:attributes="href string:${view/site_url}/++resource++collective.disclaimer/disclaimer.css">
 
 <div id="viewlet-disclaimer" role="alert" style="display: none"
     tal:attributes="data-enabled view/enabled;
                     data-last-modified view/last_modified">
-  <a class="disclaimer-close" title="Close">X</a>
   <div class="disclaimer-title" tal:content="view/title">Title</div>
   <div tal:replace="structure view/text">
     Disclaimer
   </div>
+  <button name="collective.disclaimer.ok" i18n:translate="title_button_ok">OK</button>
+  <button name="collective.disclaimer.cancel" i18n:translate="title_button_cancel">Cancel</button>
 </div>
 
 <script>
 if (Storage !== undefined) {
   $(document).ready(function () {
-    "use strict";
-    var last_modified = $("#viewlet-disclaimer").attr("data-last-modified");
-    var last_seen = localStorage.getItem("collective.disclaimer");
+    'use strict';
 
-    if (last_seen === null || last_seen < last_modified) {
-      localStorage.setItem("collective.disclaimer", last_modified);
-      var enabled = $("#viewlet-disclaimer").attr("data-enabled");
-
-      if (enabled === "true") {
-        $("#viewlet-disclaimer").show();
-      }
-
-      $(".disclaimer-close").click(function (event) {
-        event.preventDefault();
-        $("#viewlet-disclaimer").hide();
-      });
+    var enabled = $('#viewlet-disclaimer').attr('data-enabled');
+    if (enabled !== 'true') {
+      return;
     }
+
+    var last_modified = $('#viewlet-disclaimer').attr('data-last-modified');
+    var last_seen = localStorage.getItem('collective.disclaimer');
+    if (last_seen === null || last_seen < last_modified) {
+      $('#viewlet-disclaimer').show();
+    }
+
+    $('button[name="collective.disclaimer.ok"]').click(function (event) {
+      event.preventDefault();
+      localStorage.setItem('collective.disclaimer', last_modified);
+      $("#viewlet-disclaimer").hide();
+    });
+
+    $('button[name="collective.disclaimer.cancel"]').click(function (event) {
+      event.preventDefault();
+      $("#viewlet-disclaimer").hide();
+    });
+
   });
 }
 </script>

--- a/src/collective/disclaimer/browser/disclaimer.pt
+++ b/src/collective/disclaimer/browser/disclaimer.pt
@@ -10,7 +10,6 @@
       Disclaimer
     </div>
     <button name="collective.disclaimer.ok" i18n:translate="title_button_ok">OK</button>
-    <button name="collective.disclaimer.cancel" i18n:translate="title_button_cancel">Cancel</button>
 
   </div>
 
@@ -33,11 +32,6 @@
       $('button[name="collective.disclaimer.ok"]').click(function (event) {
         event.preventDefault();
         localStorage.setItem('collective.disclaimer', last_modified);
-        $("#viewlet-disclaimer").hide();
-      });
-
-      $('button[name="collective.disclaimer.cancel"]').click(function (event) {
-        event.preventDefault();
         $("#viewlet-disclaimer").hide();
       });
 

--- a/src/collective/disclaimer/browser/disclaimer.pt
+++ b/src/collective/disclaimer/browser/disclaimer.pt
@@ -1,43 +1,45 @@
-<link href="disclaimer.css" rel="stylesheet" tal:attributes="href string:${view/site_url}/++resource++collective.disclaimer/disclaimer.css">
-
 <div id="viewlet-disclaimer" role="alert" style="display: none"
     tal:attributes="data-enabled view/enabled;
                     data-last-modified view/last_modified">
+
+  <link href="disclaimer.css" rel="stylesheet" tal:attributes="href string:${view/site_url}/++resource++collective.disclaimer/disclaimer.css">
+
   <div class="disclaimer-title" tal:content="view/title">Title</div>
-  <div tal:replace="structure view/text">
+  <div class="disclaimer-text" tal:content="structure view/text">
     Disclaimer
   </div>
   <button name="collective.disclaimer.ok" i18n:translate="title_button_ok">OK</button>
   <button name="collective.disclaimer.cancel" i18n:translate="title_button_cancel">Cancel</button>
+
+  <script>
+  if (Storage !== undefined) {
+    $(document).ready(function () {
+      'use strict';
+
+      var enabled = $('#viewlet-disclaimer').attr('data-enabled');
+      if (enabled !== 'true') {
+        return;
+      }
+
+      var last_modified = $('#viewlet-disclaimer').attr('data-last-modified');
+      var last_seen = localStorage.getItem('collective.disclaimer');
+      if (last_seen === null || last_seen < last_modified) {
+        $('#viewlet-disclaimer').show();
+      }
+
+      $('button[name="collective.disclaimer.ok"]').click(function (event) {
+        event.preventDefault();
+        localStorage.setItem('collective.disclaimer', last_modified);
+        $("#viewlet-disclaimer").hide();
+      });
+
+      $('button[name="collective.disclaimer.cancel"]').click(function (event) {
+        event.preventDefault();
+        $("#viewlet-disclaimer").hide();
+      });
+
+    });
+  }
+  </script>
+
 </div>
-
-<script>
-if (Storage !== undefined) {
-  $(document).ready(function () {
-    'use strict';
-
-    var enabled = $('#viewlet-disclaimer').attr('data-enabled');
-    if (enabled !== 'true') {
-      return;
-    }
-
-    var last_modified = $('#viewlet-disclaimer').attr('data-last-modified');
-    var last_seen = localStorage.getItem('collective.disclaimer');
-    if (last_seen === null || last_seen < last_modified) {
-      $('#viewlet-disclaimer').show();
-    }
-
-    $('button[name="collective.disclaimer.ok"]').click(function (event) {
-      event.preventDefault();
-      localStorage.setItem('collective.disclaimer', last_modified);
-      $("#viewlet-disclaimer").hide();
-    });
-
-    $('button[name="collective.disclaimer.cancel"]').click(function (event) {
-      event.preventDefault();
-      $("#viewlet-disclaimer").hide();
-    });
-
-  });
-}
-</script>

--- a/src/collective/disclaimer/browser/static/disclaimer.css
+++ b/src/collective/disclaimer/browser/static/disclaimer.css
@@ -19,15 +19,15 @@
 }
 button[name="collective.disclaimer.ok"] {
     display: inline-block;
-    margin: 0 0 0 1em;
+    margin: 1em;
     padding: 0.5em;
+    border-radius: 0.2em;
     background: #00FF00;
     color: black;
-    border-radius: 0.2em;
-    opacity: 0.7;
+    border: none;
 }
 button[name="collective.disclaimer.ok"]:hover {
-    opacity: 1;
+    color: white;
 }
 .disclaimer-title {
     font-weight: bold;

--- a/src/collective/disclaimer/browser/static/disclaimer.css
+++ b/src/collective/disclaimer/browser/static/disclaimer.css
@@ -14,23 +14,31 @@
     width: 100%;
     z-index: 20180509;
 }
-a.disclaimer-close, a.disclaimer-close:hover {
-    background: #fff;
-    border-radius: 50%;
-    color: #000 !important;
-    cursor: pointer;
+.disclaimer-text {
     display: inline-block;
-    float: right;
-    font-size: 13px;
-    line-height: 18px;
-    height: 17px;
-    position: absolute;
-    right: 0.5em;
-    text-align: center;
-    text-decoration: none;
-    top: 0.5em;
-    width: 17px;
 }
+
+button[name="collective.disclaimer.ok"],
+button[name="collective.disclaimer.cancel"] {
+    display: inline-block;
+    padding: 0.5em;
+    border-radius: 0.2em;
+    opacity: 0.7;
+    color: black;
+}
+button[name="collective.disclaimer.ok"]:hover,
+button[name="collective.disclaimer.cancel"]:hover {
+    opacity: 1;
+}
+button[name="collective.disclaimer.ok"] {
+    background: #00FF00;
+    margin: 0 0 0 1em;
+}
+button[name="collective.disclaimer.cancel"] {
+    background: #FF0000;
+    margin: 0 0 0 0.5em;
+}
+
 .disclaimer-title {
     font-weight: bold;
     margin-bottom: 0.5em;

--- a/src/collective/disclaimer/browser/static/disclaimer.css
+++ b/src/collective/disclaimer/browser/static/disclaimer.css
@@ -17,28 +17,18 @@
 .disclaimer-text {
     display: inline-block;
 }
-
-button[name="collective.disclaimer.ok"],
-button[name="collective.disclaimer.cancel"] {
+button[name="collective.disclaimer.ok"] {
     display: inline-block;
+    margin: 0 0 0 1em;
     padding: 0.5em;
+    background: #00FF00;
+    color: black;
     border-radius: 0.2em;
     opacity: 0.7;
-    color: black;
 }
-button[name="collective.disclaimer.ok"]:hover,
-button[name="collective.disclaimer.cancel"]:hover {
+button[name="collective.disclaimer.ok"]:hover {
     opacity: 1;
 }
-button[name="collective.disclaimer.ok"] {
-    background: #00FF00;
-    margin: 0 0 0 1em;
-}
-button[name="collective.disclaimer.cancel"] {
-    background: #FF0000;
-    margin: 0 0 0 0.5em;
-}
-
 .disclaimer-title {
     font-weight: bold;
     margin-bottom: 0.5em;


### PR DESCRIPTION
First of all, thanks @hvelarde for saving us Europeans from the "General Data Protection Regulation" apocalypse!

Instead of just overwriting the template I'll see if these changes are useful for everyone:

- First commit: the viewlet always set the local storage key, even if the viewlet text wasn't confirmed by closing it via the close link. I think it's better to explicitly ask for confirmation ("OK") ~~or let the user cancel and close the dialog which will him get the dialog presented after the next request~~.
I removed the cancel button in my fifth commit, because it doesn't make too much sense... You have to confirm or quit.

- Second commit: when moving the viewlet via diazo into the thme, the script and css link were not moved. I included both in the viewlet element which fixes this.

- Third commit: Add a ``disclaimer-inner`` wrapper to allow easier styling, e.g. positioning the viewlet centered on the website and darkening the whole background.

- Fourth commit: Register the controlpanel for any context.
  The correct registry is automatically acquired.
  This way, it's possible to set different disclaimer texts in a Lineage site with lineage.registry installed.
 